### PR TITLE
Java: improved imports

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -37,7 +37,7 @@ jar {
                    'Implementation-Version': VERSION_NAME,
                    'Implementation-Vendor': VENDOR_NAME,
                    'Bundle-SymbolicName': POM_ARTIFACT_ID,
-                   'Export-Package': 'com.svix.*')
+                   'Export-Package': 'com.svix,com.svix.models.*')
 
         archiveVersion = VERSION_NAME
     }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -37,7 +37,7 @@ jar {
                    'Implementation-Version': VERSION_NAME,
                    'Implementation-Vendor': VENDOR_NAME,
                    'Bundle-SymbolicName': POM_ARTIFACT_ID,
-                   'Export-Package': 'com.svix,com.svix.models.*')
+                   'Export-Package': 'com.svix,com.svix.models,com.svix.exceptions')
 
         archiveVersion = VERSION_NAME
     }

--- a/java/lib/src/main/java/com/svix/Application.java
+++ b/java/lib/src/main/java/com/svix/Application.java
@@ -1,6 +1,7 @@
 package com.svix;
 
-import com.svix.api.ApplicationApi;
+import com.svix.exceptions.ApiException;
+import com.svix.internal.api.ApplicationApi;
 import com.svix.models.ApplicationIn;
 import com.svix.models.ApplicationOut;
 import com.svix.models.ListResponseApplicationOut;
@@ -13,22 +14,42 @@ public final class Application {
 	}
 
 	public ListResponseApplicationOut list(final FetchOptions options) throws ApiException {
-		return api.listApplicationsApiV1AppGet(options.getIterator(), options.getLimit());
+		try {
+			return api.listApplicationsApiV1AppGet(options.getIterator(), options.getLimit());
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public ApplicationOut create(final ApplicationIn applicationIn) throws ApiException {
-		return api.createApplicationApiV1AppPost(applicationIn);
+		try {
+			return api.createApplicationApiV1AppPost(applicationIn);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public ApplicationOut get(final String appId) throws ApiException {
-		return api.getApplicationApiV1AppAppIdGet(appId);
+		try {
+			return api.getApplicationApiV1AppAppIdGet(appId);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public ApplicationOut update(final String appId, final ApplicationIn applicationIn) throws ApiException {
-		return api.updateApplicationApiV1AppAppIdPut(appId, applicationIn);
+		try {
+			return api.updateApplicationApiV1AppAppIdPut(appId, applicationIn);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public void delete(final String appId) throws ApiException {
-		api.deleteApplicationApiV1AppAppIdDelete(appId);
+		try {
+			api.deleteApplicationApiV1AppAppIdDelete(appId);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/Application.java
+++ b/java/lib/src/main/java/com/svix/Application.java
@@ -17,7 +17,7 @@ public final class Application {
 		try {
 			return api.listApplicationsApiV1AppGet(options.getIterator(), options.getLimit());
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -25,7 +25,7 @@ public final class Application {
 		try {
 			return api.createApplicationApiV1AppPost(applicationIn);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -33,7 +33,7 @@ public final class Application {
 		try {
 			return api.getApplicationApiV1AppAppIdGet(appId);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -41,7 +41,7 @@ public final class Application {
 		try {
 			return api.updateApplicationApiV1AppAppIdPut(appId, applicationIn);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -49,7 +49,7 @@ public final class Application {
 		try {
 			api.deleteApplicationApiV1AppAppIdDelete(appId);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/Application.java
+++ b/java/lib/src/main/java/com/svix/Application.java
@@ -1,10 +1,9 @@
 package com.svix;
 
-import com.svix.generated.ApiException;
-import com.svix.generated.api.ApplicationApi;
-import com.svix.generated.model.ApplicationIn;
-import com.svix.generated.model.ApplicationOut;
-import com.svix.generated.model.ListResponseApplicationOut;
+import com.svix.api.ApplicationApi;
+import com.svix.models.ApplicationIn;
+import com.svix.models.ApplicationOut;
+import com.svix.models.ListResponseApplicationOut;
 
 public final class Application {
 	private final ApplicationApi api;
@@ -17,7 +16,7 @@ public final class Application {
 		return api.listApplicationsApiV1AppGet(options.getIterator(), options.getLimit());
 	}
 
-	public ApplicationOut create(final String appId, final ApplicationIn applicationIn) throws ApiException {
+	public ApplicationOut create(final ApplicationIn applicationIn) throws ApiException {
 		return api.createApplicationApiV1AppPost(applicationIn);
 	}
 

--- a/java/lib/src/main/java/com/svix/Authentication.java
+++ b/java/lib/src/main/java/com/svix/Authentication.java
@@ -1,6 +1,7 @@
 package com.svix;
 
-import com.svix.api.AuthenticationApi;
+import com.svix.exceptions.ApiException;
+import com.svix.internal.api.AuthenticationApi;
 import com.svix.models.DashboardAccessOut;
 
 public final class Authentication {
@@ -11,10 +12,18 @@ public final class Authentication {
 	}
 
 	public DashboardAccessOut dashboardAccess(final String appId) throws ApiException {
-		return api.getDashboardAccessApiV1AuthDashboardAccessAppIdPost(appId);
+		try {
+			return api.getDashboardAccessApiV1AuthDashboardAccessAppIdPost(appId);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public void logout() throws ApiException {
-		api.logoutApiV1AuthLogoutPost();
+		try {
+			api.logoutApiV1AuthLogoutPost();
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/Authentication.java
+++ b/java/lib/src/main/java/com/svix/Authentication.java
@@ -1,8 +1,7 @@
 package com.svix;
 
-import com.svix.generated.ApiException;
-import com.svix.generated.api.AuthenticationApi;
-import com.svix.generated.model.DashboardAccessOut;
+import com.svix.api.AuthenticationApi;
+import com.svix.models.DashboardAccessOut;
 
 public final class Authentication {
 	private final AuthenticationApi api;

--- a/java/lib/src/main/java/com/svix/Authentication.java
+++ b/java/lib/src/main/java/com/svix/Authentication.java
@@ -15,7 +15,7 @@ public final class Authentication {
 		try {
 			return api.getDashboardAccessApiV1AuthDashboardAccessAppIdPost(appId);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -23,7 +23,7 @@ public final class Authentication {
 		try {
 			api.logoutApiV1AuthLogoutPost();
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/Endpoint.java
+++ b/java/lib/src/main/java/com/svix/Endpoint.java
@@ -18,7 +18,7 @@ public final class Endpoint {
 		try {
 			return api.listEndpointsApiV1AppAppIdEndpointGet(appId, options.getIterator(), options.getLimit());
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -26,7 +26,7 @@ public final class Endpoint {
 		try {
 			return api.createEndpointApiV1AppAppIdEndpointPost(appId, endpointIn);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -34,7 +34,7 @@ public final class Endpoint {
 		try {
 			return api.getEndpointApiV1AppAppIdEndpointEndpointIdGet(endpointId, appId);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -42,7 +42,7 @@ public final class Endpoint {
 		try {
 			return api.updateEndpointApiV1AppAppIdEndpointEndpointIdPut(endpointId, appId, endpointIn);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -50,7 +50,7 @@ public final class Endpoint {
 		try {
 			api.deleteEndpointApiV1AppAppIdEndpointEndpointIdDelete(endpointId, appId);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -58,7 +58,7 @@ public final class Endpoint {
 		try {
 			return api.getEndpointSecretApiV1AppAppIdEndpointEndpointIdSecretGet(endpointId, appId);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/Endpoint.java
+++ b/java/lib/src/main/java/com/svix/Endpoint.java
@@ -1,6 +1,7 @@
 package com.svix;
 
-import com.svix.api.EndpointApi;
+import com.svix.exceptions.ApiException;
+import com.svix.internal.api.EndpointApi;
 import com.svix.models.EndpointIn;
 import com.svix.models.EndpointOut;
 import com.svix.models.EndpointSecretOut;
@@ -14,26 +15,50 @@ public final class Endpoint {
 	}
 
 	public ListResponseEndpointOut list(final String appId, final FetchOptions options) throws ApiException {
-		return api.listEndpointsApiV1AppAppIdEndpointGet(appId, options.getIterator(), options.getLimit());
+		try {
+			return api.listEndpointsApiV1AppAppIdEndpointGet(appId, options.getIterator(), options.getLimit());
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public EndpointOut create(final String appId, final EndpointIn endpointIn) throws ApiException {
-		return api.createEndpointApiV1AppAppIdEndpointPost(appId, endpointIn);
+		try {
+			return api.createEndpointApiV1AppAppIdEndpointPost(appId, endpointIn);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public EndpointOut get(final String appId, final String endpointId) throws ApiException {
-		return api.getEndpointApiV1AppAppIdEndpointEndpointIdGet(endpointId, appId);
+		try {
+			return api.getEndpointApiV1AppAppIdEndpointEndpointIdGet(endpointId, appId);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public EndpointOut update(final String appId, final String endpointId, final EndpointIn endpointIn) throws ApiException {
-		return api.updateEndpointApiV1AppAppIdEndpointEndpointIdPut(endpointId, appId, endpointIn);
+		try {
+			return api.updateEndpointApiV1AppAppIdEndpointEndpointIdPut(endpointId, appId, endpointIn);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public void delete(final String appId, final String endpointId) throws ApiException {
-		api.deleteEndpointApiV1AppAppIdEndpointEndpointIdDelete(endpointId, appId);
+		try {
+			api.deleteEndpointApiV1AppAppIdEndpointEndpointIdDelete(endpointId, appId);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public EndpointSecretOut getSecret(final String appId, final String endpointId) throws ApiException {
-		return api.getEndpointSecretApiV1AppAppIdEndpointEndpointIdSecretGet(endpointId, appId);
+		try {
+			return api.getEndpointSecretApiV1AppAppIdEndpointEndpointIdSecretGet(endpointId, appId);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/Endpoint.java
+++ b/java/lib/src/main/java/com/svix/Endpoint.java
@@ -1,11 +1,10 @@
 package com.svix;
 
-import com.svix.generated.ApiException;
-import com.svix.generated.api.EndpointApi;
-import com.svix.generated.model.EndpointIn;
-import com.svix.generated.model.EndpointOut;
-import com.svix.generated.model.EndpointSecret;
-import com.svix.generated.model.ListResponseEndpointOut;
+import com.svix.api.EndpointApi;
+import com.svix.models.EndpointIn;
+import com.svix.models.EndpointOut;
+import com.svix.models.EndpointSecretOut;
+import com.svix.models.ListResponseEndpointOut;
 
 public final class Endpoint {
 	private final EndpointApi api;
@@ -34,7 +33,7 @@ public final class Endpoint {
 		api.deleteEndpointApiV1AppAppIdEndpointEndpointIdDelete(endpointId, appId);
 	}
 
-	public EndpointSecret getSecret(final String appId, final String endpointId) throws ApiException {
+	public EndpointSecretOut getSecret(final String appId, final String endpointId) throws ApiException {
 		return api.getEndpointSecretApiV1AppAppIdEndpointEndpointIdSecretGet(endpointId, appId);
 	}
 }

--- a/java/lib/src/main/java/com/svix/EventType.java
+++ b/java/lib/src/main/java/com/svix/EventType.java
@@ -18,7 +18,7 @@ public final class EventType {
 		try {
 			return api.listEventTypesApiV1EventTypeGet(options.getIterator(), options.getLimit());
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -26,7 +26,7 @@ public final class EventType {
 		try {
 			return api.createEventTypeApiV1EventTypePost(eventTypeIn);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -34,7 +34,7 @@ public final class EventType {
 		try {
 			return api.updateEventTypeApiV1EventTypeEventTypeNamePut(eventTypeName, eventTypeUpdate);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -42,7 +42,7 @@ public final class EventType {
 		try {
 			api.deleteEventTypeApiV1EventTypeEventTypeNameDelete(eventTypeName);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/EventType.java
+++ b/java/lib/src/main/java/com/svix/EventType.java
@@ -1,6 +1,7 @@
 package com.svix;
 
-import com.svix.api.EventTypeApi;
+import com.svix.exceptions.ApiException;
+import com.svix.internal.api.EventTypeApi;
 import com.svix.models.EventTypeIn;
 import com.svix.models.EventTypeOut;
 import com.svix.models.EventTypeUpdate;
@@ -14,18 +15,34 @@ public final class EventType {
 	}
 
 	public ListResponseEventTypeOut list(final FetchOptions options) throws ApiException {
-		return api.listEventTypesApiV1EventTypeGet(options.getIterator(), options.getLimit());
+		try {
+			return api.listEventTypesApiV1EventTypeGet(options.getIterator(), options.getLimit());
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public EventTypeOut create(final EventTypeIn eventTypeIn) throws ApiException {
-		return api.createEventTypeApiV1EventTypePost(eventTypeIn);
+		try {
+			return api.createEventTypeApiV1EventTypePost(eventTypeIn);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public EventTypeOut update(final String eventTypeName, final EventTypeUpdate eventTypeUpdate) throws ApiException {
-		return api.updateEventTypeApiV1EventTypeEventTypeNamePut(eventTypeName, eventTypeUpdate);
+		try {
+			return api.updateEventTypeApiV1EventTypeEventTypeNamePut(eventTypeName, eventTypeUpdate);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public void delete(final String eventTypeName) throws ApiException {
-		api.deleteEventTypeApiV1EventTypeEventTypeNameDelete(eventTypeName);
+		try {
+			api.deleteEventTypeApiV1EventTypeEventTypeNameDelete(eventTypeName);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/EventType.java
+++ b/java/lib/src/main/java/com/svix/EventType.java
@@ -1,10 +1,10 @@
 package com.svix;
 
-import com.svix.generated.ApiException;
-import com.svix.generated.api.EventTypeApi;
-import com.svix.generated.model.EventTypeInOut;
-import com.svix.generated.model.EventTypeUpdate;
-import com.svix.generated.model.ListResponseEventTypeInOut;
+import com.svix.api.EventTypeApi;
+import com.svix.models.EventTypeIn;
+import com.svix.models.EventTypeOut;
+import com.svix.models.EventTypeUpdate;
+import com.svix.models.ListResponseEventTypeOut;
 
 public final class EventType {
 	private final EventTypeApi api;
@@ -13,15 +13,15 @@ public final class EventType {
 		api = new EventTypeApi();
 	}
 
-	public ListResponseEventTypeInOut list(final FetchOptions options) throws ApiException {
+	public ListResponseEventTypeOut list(final FetchOptions options) throws ApiException {
 		return api.listEventTypesApiV1EventTypeGet(options.getIterator(), options.getLimit());
 	}
 
-	public EventTypeInOut create(final EventTypeInOut eventTypeInOut) throws ApiException {
-		return api.createEventTypeApiV1EventTypePost(eventTypeInOut);
+	public EventTypeOut create(final EventTypeIn eventTypeIn) throws ApiException {
+		return api.createEventTypeApiV1EventTypePost(eventTypeIn);
 	}
 
-	public EventTypeInOut update(final String eventTypeName, final EventTypeUpdate eventTypeUpdate) throws ApiException {
+	public EventTypeOut update(final String eventTypeName, final EventTypeUpdate eventTypeUpdate) throws ApiException {
 		return api.updateEventTypeApiV1EventTypeEventTypeNamePut(eventTypeName, eventTypeUpdate);
 	}
 

--- a/java/lib/src/main/java/com/svix/FetchOptionsMessageAttempt.java
+++ b/java/lib/src/main/java/com/svix/FetchOptionsMessageAttempt.java
@@ -1,6 +1,6 @@
 package com.svix;
 
-import com.svix.generated.model.MessageStatus;
+import com.svix.models.MessageStatus;
 
 
 public final class FetchOptionsMessageAttempt extends FetchOptions {

--- a/java/lib/src/main/java/com/svix/Message.java
+++ b/java/lib/src/main/java/com/svix/Message.java
@@ -17,7 +17,7 @@ public final class Message {
 		try {
 			return api.listMessagesApiV1AppAppIdMsgGet(appId, options.getIterator(), options.getLimit());
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -25,7 +25,7 @@ public final class Message {
 		try {
 			return api.createMessageApiV1AppAppIdMsgPost(appId, messageIn);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -33,7 +33,7 @@ public final class Message {
 		try {
 			return api.getMessageApiV1AppAppIdMsgMsgIdGet(msgId, appId);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/Message.java
+++ b/java/lib/src/main/java/com/svix/Message.java
@@ -1,10 +1,9 @@
 package com.svix;
 
-import com.svix.generated.ApiException;
-import com.svix.generated.api.MessageApi;
-import com.svix.generated.model.ListResponseMessageOut;
-import com.svix.generated.model.MessageIn;
-import com.svix.generated.model.MessageOut;
+import com.svix.api.MessageApi;
+import com.svix.models.ListResponseMessageOut;
+import com.svix.models.MessageIn;
+import com.svix.models.MessageOut;
 
 public final class Message {
 	private final MessageApi api;

--- a/java/lib/src/main/java/com/svix/Message.java
+++ b/java/lib/src/main/java/com/svix/Message.java
@@ -1,6 +1,7 @@
 package com.svix;
 
-import com.svix.api.MessageApi;
+import com.svix.exceptions.ApiException;
+import com.svix.internal.api.MessageApi;
 import com.svix.models.ListResponseMessageOut;
 import com.svix.models.MessageIn;
 import com.svix.models.MessageOut;
@@ -13,14 +14,26 @@ public final class Message {
 	}
 
 	public ListResponseMessageOut list(final String appId, final FetchOptions options) throws ApiException {
-		return api.listMessagesApiV1AppAppIdMsgGet(appId, options.getIterator(), options.getLimit());
+		try {
+			return api.listMessagesApiV1AppAppIdMsgGet(appId, options.getIterator(), options.getLimit());
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public MessageOut create(final String appId, final MessageIn messageIn) throws ApiException {
-		return api.createMessageApiV1AppAppIdMsgPost(appId, messageIn);
+		try {
+			return api.createMessageApiV1AppAppIdMsgPost(appId, messageIn);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public MessageOut get(final String msgId, final String appId) throws ApiException {
-		return api.getMessageApiV1AppAppIdMsgMsgIdGet(msgId, appId);
+		try {
+			return api.getMessageApiV1AppAppIdMsgMsgIdGet(msgId, appId);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/MessageAttempt.java
+++ b/java/lib/src/main/java/com/svix/MessageAttempt.java
@@ -1,12 +1,11 @@
 package com.svix;
 
-import com.svix.generated.ApiException;
-import com.svix.generated.api.MessageAttemptApi;
-import com.svix.generated.model.ListResponseEndpointMessageOut;
-import com.svix.generated.model.ListResponseMessageAttemptEndpointOut;
-import com.svix.generated.model.ListResponseMessageAttemptOut;
-import com.svix.generated.model.ListResponseMessageEndpointOut;
-import com.svix.generated.model.MessageAttemptOut;
+import com.svix.api.MessageAttemptApi;
+import com.svix.models.ListResponseEndpointMessageOut;
+import com.svix.models.ListResponseMessageAttemptEndpointOut;
+import com.svix.models.ListResponseMessageAttemptOut;
+import com.svix.models.ListResponseMessageEndpointOut;
+import com.svix.models.MessageAttemptOut;
 
 public final class MessageAttempt {
 	private final MessageAttemptApi api;

--- a/java/lib/src/main/java/com/svix/MessageAttempt.java
+++ b/java/lib/src/main/java/com/svix/MessageAttempt.java
@@ -19,7 +19,7 @@ public final class MessageAttempt {
 		try {
 			return api.listAttemptsApiV1AppAppIdMsgMsgIdAttemptGet(msgId, appId, options.getIterator(), options.getLimit(), options.getMessageStatus());
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -27,7 +27,7 @@ public final class MessageAttempt {
 		try {
 			return api.getAttemptApiV1AppAppIdMsgMsgIdAttemptAttemptIdGet(attemptId, msgId, appId);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -35,7 +35,7 @@ public final class MessageAttempt {
 		try {
 			return api.resendWebhookApiV1AppAppIdMsgMsgIdEndpointEndpointIdResendPost(endpointId, msgId, appId);
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -43,7 +43,7 @@ public final class MessageAttempt {
 		try {
 			return api.listAttemptedMessagesApiV1AppAppIdEndpointEndpointIdMsgGet(endpointId, appId, options.getIterator(), options.getLimit(), options.getMessageStatus());
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -51,7 +51,7 @@ public final class MessageAttempt {
 		try {
 			return api.listAttemptedDestinationsApiV1AppAppIdMsgMsgIdEndpointGet(msgId, appId, options.getIterator(), options.getLimit());
 		} catch(com.svix.internal.ApiException e) {
-			throw (ApiException) e;
+			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
@@ -61,7 +61,7 @@ public final class MessageAttempt {
 				return api.listAttemptsForEndpointApiV1AppAppIdMsgMsgIdEndpointEndpointIdAttemptGet(msgId, appId, endpointId,
 					options.getIterator(), options.getLimit(), options.getMessageStatus());
 			} catch(com.svix.internal.ApiException e) {
-				throw (ApiException) e;
+				throw Utils.wrapInternalApiException(e);
 			}
 	}
 }

--- a/java/lib/src/main/java/com/svix/MessageAttempt.java
+++ b/java/lib/src/main/java/com/svix/MessageAttempt.java
@@ -1,6 +1,7 @@
 package com.svix;
 
-import com.svix.api.MessageAttemptApi;
+import com.svix.exceptions.ApiException;
+import com.svix.internal.api.MessageAttemptApi;
 import com.svix.models.ListResponseEndpointMessageOut;
 import com.svix.models.ListResponseMessageAttemptEndpointOut;
 import com.svix.models.ListResponseMessageAttemptOut;
@@ -15,28 +16,52 @@ public final class MessageAttempt {
 	}
 
 	public ListResponseMessageAttemptOut list(final String appId, final String msgId, final FetchOptionsMessageAttempt options) throws ApiException {
-		return api.listAttemptsApiV1AppAppIdMsgMsgIdAttemptGet(msgId, appId, options.getIterator(), options.getLimit(), options.getMessageStatus());
+		try {
+			return api.listAttemptsApiV1AppAppIdMsgMsgIdAttemptGet(msgId, appId, options.getIterator(), options.getLimit(), options.getMessageStatus());
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public MessageAttemptOut get(final String msgId, final String appId, final String attemptId) throws ApiException {
-		return api.getAttemptApiV1AppAppIdMsgMsgIdAttemptAttemptIdGet(attemptId, msgId, appId);
+		try {
+			return api.getAttemptApiV1AppAppIdMsgMsgIdAttemptAttemptIdGet(attemptId, msgId, appId);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public Object resend(final String msgId, final String appId, final String endpointId) throws ApiException {
-		return api.resendWebhookApiV1AppAppIdMsgMsgIdEndpointEndpointIdResendPost(endpointId, msgId, appId);
+		try {
+			return api.resendWebhookApiV1AppAppIdMsgMsgIdEndpointEndpointIdResendPost(endpointId, msgId, appId);
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public ListResponseEndpointMessageOut listAttemptedMessages(final String appId, final String endpointId, final FetchOptionsMessageAttempt options) throws ApiException {
-		return api.listAttemptedMessagesApiV1AppAppIdEndpointEndpointIdMsgGet(endpointId, appId, options.getIterator(), options.getLimit(), options.getMessageStatus());
+		try {
+			return api.listAttemptedMessagesApiV1AppAppIdEndpointEndpointIdMsgGet(endpointId, appId, options.getIterator(), options.getLimit(), options.getMessageStatus());
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public ListResponseMessageEndpointOut listAttemptedDestinations(final String appId, final String msgId, final FetchOptions options) throws ApiException {
-		return api.listAttemptedDestinationsApiV1AppAppIdMsgMsgIdEndpointGet(msgId, appId, options.getIterator(), options.getLimit());
+		try {
+			return api.listAttemptedDestinationsApiV1AppAppIdMsgMsgIdEndpointGet(msgId, appId, options.getIterator(), options.getLimit());
+		} catch(com.svix.internal.ApiException e) {
+			throw (ApiException) e;
+		}
 	}
 
 	public ListResponseMessageAttemptEndpointOut listAttemptsForEndpoint(final String appId, final String msgId, final String endpointId,
 		final FetchOptionsMessageAttempt options) throws ApiException {
-		return api.listAttemptsForEndpointApiV1AppAppIdMsgMsgIdEndpointEndpointIdAttemptGet(msgId, appId, endpointId,
-			options.getIterator(), options.getLimit(), options.getMessageStatus());
+			try {
+				return api.listAttemptsForEndpointApiV1AppAppIdMsgMsgIdEndpointEndpointIdAttemptGet(msgId, appId, endpointId,
+					options.getIterator(), options.getLimit(), options.getMessageStatus());
+			} catch(com.svix.internal.ApiException e) {
+				throw (ApiException) e;
+			}
 	}
 }

--- a/java/lib/src/main/java/com/svix/Svix.java
+++ b/java/lib/src/main/java/com/svix/Svix.java
@@ -1,6 +1,8 @@
 package com.svix;
 
-import com.svix.auth.HttpBearerAuth;
+import com.svix.internal.ApiClient;
+import com.svix.internal.Configuration;
+import com.svix.internal.auth.HttpBearerAuth;
 
 public final class Svix {
 	private final Application application;

--- a/java/lib/src/main/java/com/svix/Svix.java
+++ b/java/lib/src/main/java/com/svix/Svix.java
@@ -1,8 +1,6 @@
 package com.svix;
 
-import com.svix.generated.ApiClient;
-import com.svix.generated.Configuration;
-import com.svix.generated.auth.HttpBearerAuth;
+import com.svix.auth.HttpBearerAuth;
 
 public final class Svix {
 	private final Application application;

--- a/java/lib/src/main/java/com/svix/Utils.java
+++ b/java/lib/src/main/java/com/svix/Utils.java
@@ -1,0 +1,9 @@
+package com.svix;
+
+import com.svix.exceptions.ApiException;
+
+final class Utils {
+    public static ApiException wrapInternalApiException(com.svix.internal.ApiException e) {
+        return new ApiException(e.getMessage(), e, e.getCode(), e.getResponseHeaders(), e.getResponseBody());
+    }
+}

--- a/java/lib/src/main/java/com/svix/Webhook.java
+++ b/java/lib/src/main/java/com/svix/Webhook.java
@@ -23,13 +23,13 @@ public final class Webhook {
 		this.key = Base64.getDecoder().decode(secret);
 	}
 
-	public void verify(final String payload, final HttpHeaders headers) throws WebhookVerificationError {
+	public void verify(final String payload, final HttpHeaders headers) throws WebhookVerificationException {
 		Optional<String> msgId = headers.firstValue(MSG_ID_KEY);
 		List<String> msgSignature = headers.allValues(MSG_SIGNATURE_KEY);
 		Optional<String> msgTimestamp = headers.firstValue(MSG_TIMESTAMP_KEY);
 
 		if (msgId.isEmpty() || msgSignature.isEmpty() || msgTimestamp.isEmpty()) {
-			throw new WebhookVerificationError("Missing required headers");
+			throw new WebhookVerificationException("Missing required headers");
 		}
 
 		String toSign = String.format("%s.%s.%s", msgId.get(), msgTimestamp.get(), payload);
@@ -48,10 +48,10 @@ public final class Webhook {
 				return;
 			}
 		}
-		throw new WebhookVerificationError("No matching signature found");
+		throw new WebhookVerificationException("No matching signature found");
 	}
 
-	private String sign(final String toSign) throws WebhookVerificationError {
+	private String sign(final String toSign) throws WebhookVerificationException {
 		try {
 			Mac sha512Hmac = Mac.getInstance(HMAC_SHA256);
 			SecretKeySpec keySpec = new SecretKeySpec(key, HMAC_SHA256);
@@ -59,7 +59,7 @@ public final class Webhook {
 			byte[] macData = sha512Hmac.doFinal(toSign.getBytes(StandardCharsets.UTF_8));
 			return Base64.getEncoder().encodeToString(macData);
 		} catch (InvalidKeyException | NoSuchAlgorithmException e) {
-			throw new WebhookVerificationError(e.getMessage());
+			throw new WebhookVerificationException(e.getMessage());
 		}
 	}
 }

--- a/java/lib/src/main/java/com/svix/Webhook.java
+++ b/java/lib/src/main/java/com/svix/Webhook.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
+import com.svix.exceptions.WebhookVerificationException;
+
 public final class Webhook {
 	static final String MSG_ID_KEY = "svix-id";
 	static final String MSG_SIGNATURE_KEY = "svix-signature";

--- a/java/lib/src/main/java/com/svix/WebhookVerificationException.java
+++ b/java/lib/src/main/java/com/svix/WebhookVerificationException.java
@@ -3,23 +3,23 @@ package com.svix;
 import java.util.Map;
 import java.util.List;
 
-public class WebhookVerificationError extends Exception {
+public class WebhookVerificationException extends Exception {
 	private int code = 0;
 	private Map<String, List<String>> responseHeaders = null;
 	private String responseBody = null;
 
-	public WebhookVerificationError() {
+	public WebhookVerificationException() {
 	}
 
-	public WebhookVerificationError(final Throwable throwable) {
+	public WebhookVerificationException(final Throwable throwable) {
 		super(throwable);
 	}
 
-	public WebhookVerificationError(final String message) {
+	public WebhookVerificationException(final String message) {
 		super(message);
 	}
 
-	public WebhookVerificationError(final String message, final Throwable throwable, final int code,
+	public WebhookVerificationException(final String message, final Throwable throwable, final int code,
 	    final Map<String, List<String>> responseHeaders, final String responseBody) {
 		super(message, throwable);
 		this.code = code;
@@ -27,26 +27,26 @@ public class WebhookVerificationError extends Exception {
 		this.responseBody = responseBody;
 	}
 
-	public WebhookVerificationError(final String message, final int code, final Map<String, List<String>> responseHeaders,
+	public WebhookVerificationException(final String message, final int code, final Map<String, List<String>> responseHeaders,
 	    final String responseBody) {
 		this(message, (Throwable) null, code, responseHeaders, responseBody);
 	}
 
-	public WebhookVerificationError(final String message, final Throwable throwable, final int code,
+	public WebhookVerificationException(final String message, final Throwable throwable, final int code,
 	    final Map<String, List<String>> responseHeaders) {
 		this(message, throwable, code, responseHeaders, null);
 	}
 
-	public WebhookVerificationError(final int code, final Map<String, List<String>> responseHeaders, final String responseBody) {
+	public WebhookVerificationException(final int code, final Map<String, List<String>> responseHeaders, final String responseBody) {
 		this((String) null, (Throwable) null, code, responseHeaders, responseBody);
 	}
 
-	public WebhookVerificationError(final int code, final String message) {
+	public WebhookVerificationException(final int code, final String message) {
 		super(message);
 		this.code = code;
 	}
 
-	public WebhookVerificationError(final int code, final String message, final Map<String, List<String>> responseHeaders,
+	public WebhookVerificationException(final int code, final String message, final Map<String, List<String>> responseHeaders,
 	    final String responseBody) {
 		this(code, message);
 		this.responseHeaders = responseHeaders;

--- a/java/lib/src/main/java/com/svix/exceptions/ApiException.java
+++ b/java/lib/src/main/java/com/svix/exceptions/ApiException.java
@@ -1,0 +1,3 @@
+package com.svix.exceptions;
+
+public class ApiException extends com.svix.internal.ApiException{}

--- a/java/lib/src/main/java/com/svix/exceptions/ApiException.java
+++ b/java/lib/src/main/java/com/svix/exceptions/ApiException.java
@@ -1,3 +1,44 @@
 package com.svix.exceptions;
 
-public class ApiException extends com.svix.internal.ApiException{}
+import java.util.Map;
+import java.util.List;
+
+public class ApiException extends Exception {
+    private int code = 0;
+    private Map<String, List<String>> responseHeaders = null;
+    private String responseBody = null;
+
+    public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders, String responseBody) {
+        super(message, throwable);
+        this.code = code;
+        this.responseHeaders = responseHeaders;
+        this.responseBody = responseBody;
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return HTTP status code
+     */
+    public int getCode() {
+        return code;
+    }
+
+    /**
+     * Get the HTTP response headers.
+     *
+     * @return A map of list of string
+     */
+    public Map<String, List<String>> getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    /**
+     * Get the HTTP response body.
+     *
+     * @return Response body in the form of string
+     */
+    public String getResponseBody() {
+        return responseBody;
+    }
+}

--- a/java/lib/src/main/java/com/svix/exceptions/WebhookVerificationException.java
+++ b/java/lib/src/main/java/com/svix/exceptions/WebhookVerificationException.java
@@ -1,4 +1,4 @@
-package com.svix;
+package com.svix.exceptions;
 
 import java.util.Map;
 import java.util.List;

--- a/java/lib/src/main/java/com/svix/exceptions/WebhookVerificationException.java
+++ b/java/lib/src/main/java/com/svix/exceptions/WebhookVerificationException.java
@@ -1,82 +1,8 @@
 package com.svix.exceptions;
 
-import java.util.Map;
-import java.util.List;
-
 public class WebhookVerificationException extends Exception {
-	private int code = 0;
-	private Map<String, List<String>> responseHeaders = null;
-	private String responseBody = null;
-
-	public WebhookVerificationException() {
-	}
-
-	public WebhookVerificationException(final Throwable throwable) {
-		super(throwable);
-	}
 
 	public WebhookVerificationException(final String message) {
 		super(message);
-	}
-
-	public WebhookVerificationException(final String message, final Throwable throwable, final int code,
-	    final Map<String, List<String>> responseHeaders, final String responseBody) {
-		super(message, throwable);
-		this.code = code;
-		this.responseHeaders = responseHeaders;
-		this.responseBody = responseBody;
-	}
-
-	public WebhookVerificationException(final String message, final int code, final Map<String, List<String>> responseHeaders,
-	    final String responseBody) {
-		this(message, (Throwable) null, code, responseHeaders, responseBody);
-	}
-
-	public WebhookVerificationException(final String message, final Throwable throwable, final int code,
-	    final Map<String, List<String>> responseHeaders) {
-		this(message, throwable, code, responseHeaders, null);
-	}
-
-	public WebhookVerificationException(final int code, final Map<String, List<String>> responseHeaders, final String responseBody) {
-		this((String) null, (Throwable) null, code, responseHeaders, responseBody);
-	}
-
-	public WebhookVerificationException(final int code, final String message) {
-		super(message);
-		this.code = code;
-	}
-
-	public WebhookVerificationException(final int code, final String message, final Map<String, List<String>> responseHeaders,
-	    final String responseBody) {
-		this(code, message);
-		this.responseHeaders = responseHeaders;
-		this.responseBody = responseBody;
-	}
-
-	/**
-	 * Get the HTTP status code.
-	 *
-	 * @return HTTP status code
-	 */
-	public int getCode() {
-		return code;
-	}
-
-	/**
-	 * Get the HTTP response headers.
-	 *
-	 * @return A map of list of string
-	 */
-	public Map<String, List<String>> getResponseHeaders() {
-		return responseHeaders;
-	}
-
-	/**
-	 * Get the HTTP response body.
-	 *
-	 * @return Response body in the form of string
-	 */
-	public String getResponseBody() {
-		return responseBody;
 	}
 }

--- a/java/lib/src/test/java/com/svix/WebhookTest.java
+++ b/java/lib/src/test/java/com/svix/WebhookTest.java
@@ -18,7 +18,7 @@ public class WebhookTest {
 	private final Webhook webhook = new Webhook(DEFAULT_SECRET);
 
 	@Test
-	public void verifyValidPayloadAndheader() throws WebhookVerificationError {
+	public void verifyValidPayloadAndheader() throws WebhookVerificationException {
 		Map<String, List<String>> headerMap = createValidHeadersMap();
 		HttpHeaders headers = HttpHeaders.of(headerMap, new DefaultBiPredicate());
 
@@ -26,7 +26,7 @@ public class WebhookTest {
 	}
 
 	@Test
-	public void verifyValidPayloadAndheaderWithMultiplePayloads() throws WebhookVerificationError {
+	public void verifyValidPayloadAndheaderWithMultiplePayloads() throws WebhookVerificationException {
 		Map<String, List<String>> headerMap = createValidHeadersMap();
 		headerMap.put(Webhook.MSG_SIGNATURE_KEY,
 		    Arrays.asList("v2,tmIKtSyZlE3uFJELVlNIOLJ1OE=", "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="));
@@ -41,7 +41,7 @@ public class WebhookTest {
 		Map<String, List<String>> headerMap = createValidHeadersMap();
 		headerMap.remove(Webhook.MSG_ID_KEY);
 
-		assertThrows(WebhookVerificationError.class, verify(headerMap));
+		assertThrows(WebhookVerificationException.class, verify(headerMap));
 	}
 
 	@Test
@@ -49,7 +49,7 @@ public class WebhookTest {
 		Map<String, List<String>> headerMap = createValidHeadersMap();
 		headerMap.remove(Webhook.MSG_TIMESTAMP_KEY);
 
-		assertThrows(WebhookVerificationError.class, verify(headerMap));
+		assertThrows(WebhookVerificationException.class, verify(headerMap));
 	}
 
 	@Test
@@ -57,7 +57,7 @@ public class WebhookTest {
 		Map<String, List<String>> headerMap = createValidHeadersMap();
 		headerMap.remove(Webhook.MSG_SIGNATURE_KEY);
 
-		assertThrows(WebhookVerificationError.class, verify(headerMap));
+		assertThrows(WebhookVerificationException.class, verify(headerMap));
 	}
 
 	@Test
@@ -65,7 +65,7 @@ public class WebhookTest {
 		Map<String, List<String>> headerMap = createValidHeadersMap();
 		headerMap.put(Webhook.MSG_SIGNATURE_KEY, Arrays.asList("v2,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="));
 
-		assertThrows(WebhookVerificationError.class, verify(headerMap));
+		assertThrows(WebhookVerificationException.class, verify(headerMap));
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class WebhookTest {
 		Map<String, List<String>> headerMap = createValidHeadersMap();
 		headerMap.put(Webhook.MSG_SIGNATURE_KEY, Arrays.asList("invalid_signature"));
 
-		assertThrows(WebhookVerificationError.class, verify(headerMap));
+		assertThrows(WebhookVerificationException.class, verify(headerMap));
 	}
 
 	@Test
@@ -81,7 +81,7 @@ public class WebhookTest {
 		Map<String, List<String>> headerMap = createValidHeadersMap();
 		headerMap.put(Webhook.MSG_SIGNATURE_KEY, Arrays.asList("v1,invalid_signature"));
 
-		assertThrows(WebhookVerificationError.class, verify(headerMap));
+		assertThrows(WebhookVerificationException.class, verify(headerMap));
 	}
 
 	private Map<String, List<String>> createValidHeadersMap() {
@@ -95,7 +95,7 @@ public class WebhookTest {
 	private ThrowingRunnable verify(final Map<String, List<String>> headerMap) {
 		return new ThrowingRunnable() {
 			@Override
-			public void run() throws WebhookVerificationError {
+			public void run() throws WebhookVerificationException {
 				HttpHeaders headers = HttpHeaders.of(headerMap, new DefaultBiPredicate());
 				webhook.verify(VALID_PAYLOAD, headers);
 			}

--- a/java/lib/src/test/java/com/svix/WebhookTest.java
+++ b/java/lib/src/test/java/com/svix/WebhookTest.java
@@ -11,6 +11,8 @@ import java.util.function.BiPredicate;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 
+import com.svix.exceptions.WebhookVerificationException;
+
 public class WebhookTest {
 	private static final String DEFAULT_SECRET = "MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
 	private static final String VALID_PAYLOAD = "{\"test\": 2432232314}";

--- a/java/openapi-generator-config.json
+++ b/java/openapi-generator-config.json
@@ -1,4 +1,4 @@
 {
-  "apiPackage": "com.svix.generated.api",
-  "modelPackage": "com.svix.generated.model"
+  "apiPackage": "com.svix.api",
+  "modelPackage": "com.svix.models"
 }

--- a/java/openapi-generator-config.json
+++ b/java/openapi-generator-config.json
@@ -1,4 +1,4 @@
 {
-  "apiPackage": "com.svix.api",
+  "apiPackage": "com.svix.internal.api",
   "modelPackage": "com.svix.models"
 }


### PR DESCRIPTION
Improves the usage a bit and pulls in the new openapi changes.

Models are now at `com.svix.models`, api is at `com.svix.internal.api`.

It still exposes the internal openapi code but I don't think its possible to avoid this.  Its now all under `com.svix.internal` though so at least we can be explicit about our compatibility promise (i.e. dont use com.svix.internal).

Creating an application now looks like this
```java
import com.svix.Svix;
import com.svix.models.ApplicationIn;
import com.svix.exceptions.ApiException;

Svix svix = new Svix("AUTH_TOKEN");
try {
    svix.getApplication().create(new ApplicationIn().name("hello");
} catch(ApiException e) {
    System.out.println(e);
}
```
And a Webhook Verification looks like this:
```java
import com.svix.Webhook;
import com.svix.exceptions.WebhookVerificationException;

Webhook webhook = new Webhook("SECRET");
try {
    webhook.verify("payload", headers);
} catch(WebhookVerificationException e) {
    System.out.println(e);
}
```